### PR TITLE
Feat: Retrieval of decal information

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -112,10 +112,10 @@ export const ATTRIBUTE_HANDLERS: Record<number, Interpreters> = {
     // Unusual effect
     134: ["effect", getIntFromFloat],
     142: ["paint", getHexStringFromFloat],
-    152: ["customTexture", getDecalUGCID], // decal lower int32 component
+    152: ["decal", getDecalUGCID], // decal lower int32 component
     187: ["crateNo", getIntFromFloat],
     214: ["hasKillEater", exists],
-    227: ["customTexture", getDecalUGCID], // decal higher int32 component
+    227: ["decal", getDecalUGCID], // decal higher int32 component
     229: ["craft", getInt],
     261: ["paint_other", getHexStringFromFloat],
     380: ["parts", getIntFromFloatAsArray],
@@ -191,6 +191,10 @@ export function parseFabricatorAttributes(fabAttribute: FabricatorAttribute[]) {
 
 export function parseAttributes(itemAttributes: Attribute[]) {
     let parsed = {} as InterpretedAttributes;
+
+    // the ugcid parser relies on both attributes being present
+    // but knowing steam some items might have malformed data, so we reset state just in case;
+    ugcidInt32Store = BIGINT_ZERO;
 
     const attributes = itemAttributes.map(a => a.def_index);
     for (const attribute of itemAttributes) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -80,7 +80,7 @@ let ugcidInt32Store = BIGINT_ZERO;
  * @param data Buffer to parse
  * @param attribute entire attribute tag (to identify which attribute we're parsing)
  * 
- * @returns undefined if ugcid is not complete, 
+ * @returns undefined if ugcid is not complete, the string representation of the UGCID otherwise 
  */
 const getDecalUGCID = (data: Buffer, attribute?: Attribute) => {
     let isAlreadySet = !!ugcidInt32Store;

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,7 +158,7 @@ interface PreserveStringAlias extends String {};
 /**  
  * Int64 User Generated Content Identifier.
  * 
- * Data can be retrieved by sending GET to 
+ * URL to retrieve the image can be retrieved by sending GET to 
  * ISteamRemoteStorage/GetUGCFileDetails/v1/ 
 */
 type UGCID = string & PreserveStringAlias

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,7 @@ export type InterpretedAttributes<T extends number | string = number> = {
     elevated?: boolean;
     outputItem?: FabricatorItem<T>;
     inputItems?: FabricatorItem<T>[];
-    customTexture?: UGCID; // applied decal id, see UGCID for more info
+    decal?: UGCID; // applied decal id, see UGCID for more info
 };
 
 export type MainAttributes = {
@@ -111,7 +111,7 @@ Interpreter<'medalNo'> |
 Interpreter<'target'>|
 Interpreter<'hasKillEater'> |
 Interpreter<'series'> | 
-Interpreter<'customTexture'>
+Interpreter<'decal'>
 
 export type SchemaImposedProperties = Partial<{
     nonTradeable: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,7 @@ export type InterpretedAttributes<T extends number | string = number> = {
     elevated?: boolean;
     outputItem?: FabricatorItem<T>;
     inputItems?: FabricatorItem<T>[];
+    customTexture?: UGCID; // applied decal id, see UGCID for more info
 };
 
 export type MainAttributes = {
@@ -109,7 +110,8 @@ Interpreter<'crateNo'> |
 Interpreter<'medalNo'> |
 Interpreter<'target'>|
 Interpreter<'hasKillEater'> |
-Interpreter<'series'>
+Interpreter<'series'> | 
+Interpreter<'customTexture'>
 
 export type SchemaImposedProperties = Partial<{
     nonTradeable: true,
@@ -150,3 +152,13 @@ type ItemsGameItem = {
     prefab?: string
     [key: string]: any
 }
+
+interface PreserveStringAlias extends String {};
+
+/**  
+ * Int64 User Generated Content Identifier.
+ * 
+ * Data can be retrieved by sending GET to 
+ * ISteamRemoteStorage/GetUGCFileDetails/v1/ 
+*/
+type UGCID = string & PreserveStringAlias


### PR DESCRIPTION
Support for parsing out the UGCID from attributes 152/227.
Tested it locally on https://backpack.tf/item/6854018826

UGCID:
1686024608989313949

FILE:
https://steamuserimages-a.akamaihd.net/ugc/1686024608989313949/E271F5F204DA12BD6D743D9EAF6092FD3038E662/

It should work the same for all the other decal items


